### PR TITLE
Changing the flocking so that it allows reloading

### DIFF
--- a/templates/ubuntu/unicorn-upstart.conf.erb
+++ b/templates/ubuntu/unicorn-upstart.conf.erb
@@ -23,13 +23,15 @@ script
   bundle exec unicorn -c <%= @name %> -D -E <%= @rack_env %>;
 
   # Give unicorn 10 seconds to initialize and establish it's write lock.
-  # This prevents initctl start from spinning up 2 unicorn masters and
-  # also rate limits unicorn master restarts.
+  # This also rate limits unicorn master restarts.
   sleep 10
 
   # Wait for the write lock held by the unicorn master. If a write lock is
   # acheived by this upstart script it means the unicorn master has exited.
-  flock -x 0 < <%= @pid %>.lock
+  #
+  # The flock timeout is necessary to allow USR2 (reload) through to the
+  # trap.
+  until `flock -w 1 -x 0 < <%= @pid %>.lock`; do sleep 0; done
 
 end script
 


### PR DESCRIPTION
Reloading was not working because since the flock at the end of the unicorn upstart script blocked indefinitely it blocked any USR2 signals from getting through to the trap. The loop fixes that by periodically coming out of flock, at which point a USR2 trap can be ran if needed.