### PR TITLE
Adding respawn to the initctl conf

### DIFF
--- a/templates/ubuntu/unicorn-upstart.conf.erb
+++ b/templates/ubuntu/unicorn-upstart.conf.erb
@@ -6,6 +6,7 @@ stop on runlevel [!2345]
 # Send a USR2 to it to reload the application in a new unicorn process
 reload signal USR2
 
+respawn
 respawn limit unlimited
 
 


### PR DESCRIPTION
respawn limit without respawn does nothing. See http://upstart.ubuntu.com/cookbook/#respawn-limit